### PR TITLE
fix(deno-lint): getOptions is now provided by webpack@5

### DIFF
--- a/packages/deno-lint/package.json
+++ b/packages/deno-lint/package.json
@@ -70,7 +70,6 @@
   },
   "dependencies": {
     "clipanion": "^3.1.0",
-    "loader-utils": "^3.2.0",
     "typanion": "^3.7.1"
   },
   "devDependencies": {

--- a/packages/deno-lint/webpack-loader.js
+++ b/packages/deno-lint/webpack-loader.js
@@ -1,10 +1,8 @@
-const { getOptions } = require('loader-utils')
-
 const { lint } = require('./index')
 
 module.exports = function denoLintLoader(source, sm) {
   const callback = this.async()
-  const options = getOptions(this)
+  const options = this.getOptions()
   const diagnostics = lint(this.resourcePath, source, options.enableAllRules)
 
   if (this.resourcePath.endsWith('diff-size.ts')) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4396,11 +4396,6 @@ loader-runner@^4.2.0:
   resolved "https://registry.npmjs.org/loader-runner/-/loader-runner-4.2.0.tgz#d7022380d66d14c5fb1d496b89864ebcfd478384"
   integrity sha512-92+huvxMvYlMzMt0iIOukcwYBFpkYJdpl2xsZ7LrlayO7E8SOv+JJUEK17B/dJIHAOLMfh2dZZ/Y18WgmGtYNw==
 
-loader-utils@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.0.tgz#bcecc51a7898bee7473d4bc6b845b23af8304d4f"
-  integrity sha512-HVl9ZqccQihZ7JM85dco1MvO9G+ONvxoGa9rkhzFsneGLKSUg1gJf9bWzhRhcvm2qChhWpebQhP44qxjKIUCaQ==
-
 locate-path@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"


### PR DESCRIPTION
loader-utils do not provide getOptions() anymore, it moved to
webpack's core since webpack 5:
https://webpack.js.org/api/loaders/#thisgetoptionsschema