### PR TITLE
Add homepage and repository in package.json of @node-rs/argon2

### DIFF
--- a/packages/argon2/package.json
+++ b/packages/argon2/package.json
@@ -41,6 +41,10 @@
   "engines": {
     "node": ">= 10"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/napi-rs/node-rs.git"
+  },
   "scripts": {
     "artifacts": "napi artifacts -d ../../artifacts",
     "bench": "cross-env NODE_ENV=production node benchmark/argon2.js",

--- a/packages/argon2/package.json
+++ b/packages/argon2/package.json
@@ -2,6 +2,7 @@
   "name": "@node-rs/argon2",
   "version": "1.1.1",
   "description": "RustCrypto: Argon2 binding for Node.js",
+  "homepage": "https://github.com/napi-rs/node-rs",
   "main": "index.js",
   "types": "index.d.ts",
   "keywords": [


### PR DESCRIPTION
The homepage and repository are missing in package.json of @node-rs/argon2.