### PR TITLE
Support eslint-disable in the lint function too

### DIFF
--- a/packages/deno-lint/src/lib.rs
+++ b/packages/deno-lint/src/lib.rs
@@ -46,6 +46,7 @@ fn lint(
       get_recommended_rules()
     })
     .media_type(get_media_type(Path::new(file_name.as_str())))
+    .ignore_file_directive("eslint-disable")
     .ignore_diagnostic_directive("eslint-disable-next-line")
     .build();
 


### PR DESCRIPTION
Make it consistent with the `denolint` function. As long as they are not compatile, it's difficult to use `denolint` for the whole project and `lint` for a single file in an IDE plugin.

Probably fixes #630.