### PR TITLE
Support list of rules to exclude and include in lint and webpack

### DIFF
--- a/packages/deno-lint/README.md
+++ b/packages/deno-lint/README.md
@@ -53,7 +53,7 @@ Lint benchmark bench suite: Fastest is @node-rs/deno-lint
 ```ts
 import { lint } from '@node-rs/deno-lint'
 
-lint(filepath, source, enableAllRules)
+lint(filepath, source, enableAllRules, excludeRules)
 ```
 
 ## webpack-loader
@@ -85,6 +85,13 @@ You can pass denolint options using standard webpack loader options.
 - Default: `false`
 
 Whether to enable all rules. If false, `denolint` will enable all recommend rules.
+
+#### `excludeRules`
+
+- Type: `String[]`
+- Default: `[]`
+
+Rules to exclude from all or recommended ones chosen by `enableAllRules`.
 
 #### `failOnError`
 

--- a/packages/deno-lint/README.md
+++ b/packages/deno-lint/README.md
@@ -53,7 +53,7 @@ Lint benchmark bench suite: Fastest is @node-rs/deno-lint
 ```ts
 import { lint } from '@node-rs/deno-lint'
 
-lint(filepath, source, enableAllRules, excludeRules)
+lint(filepath, source, enableAllRules, excludeRules, includeRules)
 ```
 
 ## webpack-loader
@@ -92,6 +92,13 @@ Whether to enable all rules. If false, `denolint` will enable all recommend rule
 - Default: `[]`
 
 Rules to exclude from all or recommended ones chosen by `enableAllRules`.
+
+#### `includeRules`
+
+- Type: `String[]`
+- Default: `[]`
+
+Rules to include in addition to the recommended ones chosen by `enableAllRules` set to `false`.
 
 #### `failOnError`
 

--- a/packages/deno-lint/index.d.ts
+++ b/packages/deno-lint/index.d.ts
@@ -7,5 +7,6 @@ export function lint(
   fileName: string,
   sourceCode: string | Buffer,
   allRules?: boolean | undefined | null,
+  excludeRules?: Array<string> | undefined | null,
 ): Array<string>
 export function denolint(dirname: string, configPath: string): boolean

--- a/packages/deno-lint/index.d.ts
+++ b/packages/deno-lint/index.d.ts
@@ -8,5 +8,6 @@ export function lint(
   sourceCode: string | Buffer,
   allRules?: boolean | undefined | null,
   excludeRules?: Array<string> | undefined | null,
+  includeRules?: Array<string> | undefined | null,
 ): Array<string>
 export function denolint(dirname: string, configPath: string): boolean

--- a/packages/deno-lint/src/config.rs
+++ b/packages/deno-lint/src/config.rs
@@ -42,23 +42,27 @@ pub fn load_from_json(config_path: &Path) -> Result<Config, std::io::Error> {
   Ok(config)
 }
 
-pub fn filter_rules(all: bool, exclude: Option<Vec<String>>) -> Vec<Arc<dyn LintRule>> {
-  match exclude {
-    Some(exclude) => {
-      let tags = if all {
-        vec![]
-      } else {
-        vec!["recommended".to_string()]
-      };
-      get_filtered_rules(Some(tags), Some(exclude.clone()), Some(vec![]))
-    }
-    None => {
-      if all {
-        get_all_rules()
-      } else {
-        get_recommended_rules()
-      }
-    }
+pub fn filter_rules(
+  all: bool,
+  exclude: Option<Vec<String>>,
+  include: Option<Vec<String>>,
+) -> Vec<Arc<dyn LintRule>> {
+  if exclude.is_some() || include.is_some() {
+    let tags = if all {
+      vec![]
+    } else {
+      vec!["recommended".to_string()]
+    };
+    return get_filtered_rules(
+      Some(tags),
+      Some(exclude.unwrap_or_default()),
+      Some(include.unwrap_or_default()),
+    );
+  }
+  if all {
+    get_all_rules()
+  } else {
+    get_recommended_rules()
   }
 }
 

--- a/packages/deno-lint/src/config.rs
+++ b/packages/deno-lint/src/config.rs
@@ -1,5 +1,5 @@
 // Copyright 2020-2021 the Deno authors. All rights reserved. MIT license.
-use deno_lint::rules::{get_filtered_rules, LintRule};
+use deno_lint::rules::{get_all_rules, get_filtered_rules, get_recommended_rules, LintRule};
 use serde::Deserialize;
 use std::path::Path;
 use std::sync::Arc;
@@ -40,6 +40,26 @@ pub fn load_from_json(config_path: &Path) -> Result<Config, std::io::Error> {
   let json_str = std::fs::read_to_string(config_path)?;
   let config: Config = serde_json::from_str(&json_str)?;
   Ok(config)
+}
+
+pub fn filter_rules(all: bool, exclude: Option<Vec<String>>) -> Vec<Arc<dyn LintRule>> {
+  match exclude {
+    Some(exclude) => {
+      let tags = if all {
+        vec![]
+      } else {
+        vec!["recommended".to_string()]
+      };
+      get_filtered_rules(Some(tags), Some(exclude.clone()), Some(vec![]))
+    }
+    None => {
+      if all {
+        get_all_rules()
+      } else {
+        get_recommended_rules()
+      }
+    }
+  }
 }
 
 #[cfg(test)]

--- a/packages/deno-lint/src/lib.rs
+++ b/packages/deno-lint/src/lib.rs
@@ -38,11 +38,13 @@ fn lint(
   source_code: Either<String, Buffer>,
   all_rules: Option<bool>,
   exclude_rules: Option<Vec<String>>,
+  include_rules: Option<Vec<String>>,
 ) -> Result<Vec<String>> {
   let linter = LinterBuilder::default()
     .rules(config::filter_rules(
       all_rules.unwrap_or(false),
       exclude_rules,
+      include_rules,
     ))
     .media_type(get_media_type(Path::new(file_name.as_str())))
     .ignore_diagnostic_directive("eslint-disable-next-line")

--- a/packages/deno-lint/src/lib.rs
+++ b/packages/deno-lint/src/lib.rs
@@ -12,7 +12,7 @@ use std::str;
 
 use deno_ast::MediaType;
 use deno_lint::linter::LinterBuilder;
-use deno_lint::rules::{get_all_rules, get_recommended_rules};
+use deno_lint::rules::get_recommended_rules;
 use ignore::types::TypesBuilder;
 use ignore::WalkBuilder;
 use napi::bindgen_prelude::*;
@@ -37,14 +37,13 @@ fn lint(
   file_name: String,
   source_code: Either<String, Buffer>,
   all_rules: Option<bool>,
+  exclude_rules: Option<Vec<String>>,
 ) -> Result<Vec<String>> {
-  let all_rules = all_rules.unwrap_or(false);
   let linter = LinterBuilder::default()
-    .rules(if all_rules {
-      get_all_rules()
-    } else {
-      get_recommended_rules()
-    })
+    .rules(config::filter_rules(
+      all_rules.unwrap_or(false),
+      exclude_rules,
+    ))
     .media_type(get_media_type(Path::new(file_name.as_str())))
     .ignore_diagnostic_directive("eslint-disable-next-line")
     .build();

--- a/packages/deno-lint/webpack-loader.js
+++ b/packages/deno-lint/webpack-loader.js
@@ -3,7 +3,13 @@ const { lint } = require('./index')
 module.exports = function denoLintLoader(source, sm) {
   const callback = this.async()
   const options = this.getOptions()
-  const diagnostics = lint(this.resourcePath, source, options.enableAllRules, options.excludeRules)
+  const diagnostics = lint(
+    this.resourcePath,
+    source,
+    options.enableAllRules,
+    options.excludeRules,
+    options.includeRules,
+  )
 
   if (this.resourcePath.endsWith('diff-size.ts')) {
     this.emitWarning(`${this.resourcePath}, ${diagnostics.length}`)

--- a/packages/deno-lint/webpack-loader.js
+++ b/packages/deno-lint/webpack-loader.js
@@ -3,7 +3,7 @@ const { lint } = require('./index')
 module.exports = function denoLintLoader(source, sm) {
   const callback = this.async()
   const options = this.getOptions()
-  const diagnostics = lint(this.resourcePath, source, options.enableAllRules)
+  const diagnostics = lint(this.resourcePath, source, options.enableAllRules, options.excludeRules)
 
   if (this.resourcePath.endsWith('diff-size.ts')) {
     this.emitWarning(`${this.resourcePath}, ${diagnostics.length}`)


### PR DESCRIPTION
While `enableAllRules` serves as `"tags": ["recommended"]`, there is no way to specify `"exclude": [...]` and `"include": [...]` as known from `.denolint.json`. Adding arguments `excludeRules` and `includeRules` is not exactly according to the config schema, but `enableAllRules` is not either. And it is the simplest change without breaking the current arguments.

Attempts to help implementing IDE plugins using `denolint`, as mentioned [in a comment](https://github.com/napi-rs/node-rs/issues/631#issuecomment-1256899427) at #631.

Another way could be expecting `RulesConfig` as an `Either` with the `bool`. It would need implementing serialisation of `RulesConfig`.