### PR TITLE
feat(argon2): support salt input on Argon2

### DIFF
--- a/packages/argon2/__test__/argon2.spec.ts
+++ b/packages/argon2/__test__/argon2.spec.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'crypto'
 
 import test from 'ava'
 
-import { Algorithm, hash, verify, Version } from '../index.js'
+import { Algorithm, hash, hashRaw, verify, Version } from '../index.js'
 
 const passwordString = 'some_string123'
 const passwordBuffer = Buffer.from(passwordString)
@@ -43,10 +43,10 @@ test('should be able to hash string', async (t) => {
   )
 })
 
-test('should be able to hash string with a defined salt', async (t) => {
+test('should be able to hashRaw string with a defined salt', async (t) => {
   await t.notThrowsAsync(() => hash('whatever'))
   await t.notThrowsAsync(() =>
-    hash('whatever', {
+    hashRaw('whatever', {
       secret: randomBytes(32),
       salt: randomBytes(32),
     }),

--- a/packages/argon2/__test__/argon2.spec.ts
+++ b/packages/argon2/__test__/argon2.spec.ts
@@ -43,6 +43,16 @@ test('should be able to hash string', async (t) => {
   )
 })
 
+test('should be able to hash string with a defined salt', async (t) => {
+  await t.notThrowsAsync(() => hash('whatever'))
+  await t.notThrowsAsync(() =>
+    hash('whatever', {
+      secret: randomBytes(32),
+      salt: randomBytes(32),
+    }),
+  )
+})
+
 test('should be able to verify hashed string', async (t) => {
   const PASSWORD = 'Argon2_is_the_best_algorithm_ever'
   t.true(await verify(await hash(PASSWORD), PASSWORD))
@@ -88,7 +98,7 @@ test('should return memoryCost error', async (t) => {
     }),
   )
 
-  t.is(error.message, 'memory cost is too small')
+  t.is(error?.message, 'memory cost is too small')
 })
 
 test('should return timeCost error', async (t) => {
@@ -98,7 +108,7 @@ test('should return timeCost error', async (t) => {
     }),
   )
 
-  t.is(error.message, 'time cost is too small')
+  t.is(error?.message, 'time cost is too small')
 })
 
 test('should return parallelism error', async (t) => {
@@ -109,5 +119,5 @@ test('should return parallelism error', async (t) => {
     }),
   )
 
-  t.is(error.message, 'not enough threads')
+  t.is(error?.message, 'not enough threads')
 })

--- a/packages/argon2/index.d.ts
+++ b/packages/argon2/index.d.ts
@@ -64,6 +64,7 @@ export interface Options {
   algorithm?: Algorithm
   version?: Version
   secret?: Buffer
+  salt?: Buffer
 }
 export function hash(
   password: string | Buffer,

--- a/packages/argon2/src/lib.rs
+++ b/packages/argon2/src/lib.rs
@@ -89,6 +89,7 @@ pub struct Options {
   pub algorithm: Option<Algorithm>,
   pub version: Option<Version>,
   pub secret: Option<Buffer>,
+  pub salt: Option<Buffer>,
 }
 
 impl Options {
@@ -121,7 +122,12 @@ impl Task for HashTask {
   type JsValue = String;
 
   fn compute(&mut self) -> Result<Self::Output> {
-    let salt = SaltString::generate(&mut OsRng);
+    let salt: SaltString;
+    if let Some(provided_salt) = &self.options.salt {
+      salt = SaltString::new(std::str::from_utf8(provided_salt.as_ref()).unwrap()).unwrap()
+    } else {
+      salt = SaltString::generate(&mut OsRng);
+    }
     let hasher = self.options.to_argon();
     hasher
       .map_err(|err| Error::new(Status::InvalidArg, format!("{err}")))?
@@ -181,7 +187,12 @@ impl Task for RawHashTask {
   type JsValue = Buffer;
 
   fn compute(&mut self) -> Result<Self::Output> {
-    let salt = SaltString::generate(&mut OsRng);
+    let salt: SaltString;
+    if let Some(provided_salt) = &self.options.salt {
+      salt = SaltString::new(std::str::from_utf8(provided_salt.as_ref()).unwrap()).unwrap()
+    } else {
+      salt = SaltString::generate(&mut OsRng);
+    }
     let hasher = self
       .options
       .to_argon()


### PR DESCRIPTION
Hello,

I tried to implement supporting a pre-defined salt for the argon2 hashing. 
I'm not familiar with Rust so I struggle to manage the conversion from the Js Buffer and the Rust SaltString, there are some unrecognized chars in the buffer.

I'm not sure why but this package isn't using the types defined in the [documentation](https://napi.rs/docs/compat-mode/concepts/js-values) so I tried a few things without success.

Let me know if it's doable, that will be really helpful for us to have the salt supported 👍 
