### PR TITLE
feat: upgrade toolchain to 1.80.1

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2024-07-04"
+channel = "1.80.1"
 profile = "default"


### PR DESCRIPTION
Upgrade toolchain to 1.80.x for arm crc32 which is already been stabilization.



Related issue: 
https://github.com/rust-lang/stdarch/pull/1573
https://github.com/rust-lang/rust/issues/117215