### PR TITLE
chore: migrate Renovate preset to recommended

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-  "extends": ["config:base", ":preserveSemverRanges"],
+  "extends": ["config:recommended", ":preserveSemverRanges"],
   "packageRules": [
     {
       "automerge": true,


### PR DESCRIPTION
## Summary
- migrate Renovate's deprecated `config:base` preset to `config:recommended`
- preserve the existing `:preserveSemverRanges` extension, package rules, Rust toolchain grouping, and weekly lock-file maintenance schedule

## Verification
- `python3 -m json.tool renovate.json`
- `git diff --check`

This addresses the Config Migration Needed item in the Dependency Dashboard without changing dependency update policy beyond the preset migration.
