### PR TITLE
perf(argon2): simdutf8, crate PHC decode, argon2-rust 1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rand = "0.10"
 rand_core = { version = "0.10" }
 serde = "1.0"
 serde_json = "1.0"
+simdutf8 = "0.1"
 xxhash-rust = { version = "0.8", features = ["xxh32", "const_xxh32", "xxh64", "const_xxh64", "xxh3", "const_xxh3"] }
 [profile.release]
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-argon2-rust = { version = "1", path = "../argon2-rust", default-features = false }
+argon2-rust = { version = "1.1", default-features = false }
 base64 = { version = "0.23" }
 bcrypt = "0.19"
 blowfish = { version = "0.10", features = ["bcrypt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
-argon2-rust = { version = "1", default-features = false }
+argon2-rust = { version = "1", path = "../argon2-rust", default-features = false }
 base64 = { version = "0.23" }
 bcrypt = "0.19"
 blowfish = { version = "0.10", features = ["bcrypt"] }

--- a/packages/argon2/Cargo.toml
+++ b/packages/argon2/Cargo.toml
@@ -16,6 +16,7 @@ global_alloc = { workspace = true }
 napi = { workspace = true, features = ["napi3"] }
 napi-derive = { workspace = true, default-features = false, features = ["type-def"] }
 rand = { workspace = true }
+simdutf8 = { workspace = true }
 
 [build-dependencies]
 napi-build = { workspace = true }

--- a/packages/argon2/Cargo.toml
+++ b/packages/argon2/Cargo.toml
@@ -11,7 +11,6 @@ parallel = ["argon2-rust/parallel"]
 
 [dependencies]
 argon2-rust = { workspace = true, features = ["std", "zeroize-memory"] }
-base64 = { workspace = true }
 global_alloc = { workspace = true }
 napi = { workspace = true, features = ["napi3"] }
 napi-derive = { workspace = true, default-features = false, features = ["type-def"] }

--- a/packages/argon2/README.md
+++ b/packages/argon2/README.md
@@ -32,7 +32,7 @@ Comparing each library's **defaults** is not 1:1. `@node-rs/argon2` defaults to 
 
 This bench pins the same password, salt, Argon2id v=19, m, t, p, and 32-byte tag. Only the **raw** KDF is timed. The tag is asserted equal on every run. Native impls are interleaved with each other; JS/wasm are a separate group so a 7 ms hash is not timed after a 400 ms JS loop.
 
-Apple M5 Max / arm64 / Node 24 / [argon2-rust 1.0.0](https://crates.io/crates/argon2-rust). Median ms. See [benchmark/](benchmark/argon2.ts).
+Apple M5 Max / arm64 / Node 24 / [argon2-rust 1.1.0](https://crates.io/crates/argon2-rust). Median ms. See [benchmark/](benchmark/argon2.ts).
 
 **Native async raw** — same calling shape as node-argon2 (no sync API there):
 

--- a/packages/argon2/src/lib.rs
+++ b/packages/argon2/src/lib.rs
@@ -156,15 +156,6 @@ fn thread_budget(lanes: u32) -> u32 {
   lanes.min(available)
 }
 
-fn try_zeroed(len: usize) -> Result<Vec<u8>> {
-  let mut tag = Vec::new();
-  tag
-    .try_reserve_exact(len)
-    .map_err(|_| map_error(Argon2Error::MemoryAllocationError))?;
-  tag.resize(len, 0);
-  Ok(tag)
-}
-
 fn map_error(err: Argon2Error) -> Error {
   let status = match err {
     Argon2Error::DecodingFail | Argon2Error::EncodingFail => Status::InvalidArg,
@@ -200,160 +191,27 @@ fn generate_salt() -> [u8; argon2_rust::RANDOM_SALT_LEN] {
   rand::random()
 }
 
-fn encode_phc(argon2: &Argon2, salt: &[u8], tag: &[u8]) -> Result<String> {
-  Ok(format!(
-    "${}$v={}$m={},t={},p={}${}${}",
-    argon2.algorithm().as_str(),
-    argon2.version().as_u32(),
-    argon2.params().memory_kib(),
-    argon2.params().passes(),
-    argon2.params().lanes(),
-    argon2_rust::encode_base64(salt).map_err(map_error)?,
-    argon2_rust::encode_base64(tag).map_err(map_error)?,
-  ))
-}
-
 fn hash_encoded(argon2: &Argon2, password: &[u8], salt: &[u8], secret: &[u8]) -> Result<String> {
-  if secret.is_empty() {
-    return argon2.hash_encoded(password, salt).map_err(map_error);
-  }
-  let mut tag = try_zeroed(argon2.params().tag_len_bytes())?;
   argon2
-    .hash_into_with_ad(password, salt, secret, &[], &mut tag)
-    .map_err(map_error)?;
-  encode_phc(argon2, salt, &tag)
+    .hash_encoded_with_ad(password, salt, secret, &[])
+    .map_err(map_error)
 }
 
 fn hash_raw_bytes(argon2: &Argon2, password: &[u8], salt: &[u8], secret: &[u8]) -> Result<Vec<u8>> {
-  let mut tag = try_zeroed(argon2.params().tag_len_bytes())?;
   argon2
-    .hash_into_with_ad(password, salt, secret, &[], &mut tag)
-    .map_err(map_error)?;
-  Ok(tag)
+    .hash_with_ad(password, salt, secret, &[])
+    .map_err(map_error)
 }
 
-fn decode_fail<T>() -> Result<T> {
-  Err(Error::new(
-    Status::InvalidArg,
-    format!("Invalid hashed password: {}", Argon2Error::DecodingFail),
-  ))
-}
-
-fn parse_phc_u32(value: &str) -> Result<u32> {
-  value.parse().or_else(|_| decode_fail())
-}
-
-fn decode_b64(input: &str) -> Result<Vec<u8>> {
-  argon2_rust::decode_base64(input.as_bytes()).map_err(map_error)
-}
-
-struct DecodedPhc {
-  algorithm: Argon2Algorithm,
-  version: Argon2Version,
-  params: Params,
-  salt: Vec<u8>,
-  hash: Vec<u8>,
-  ad: Vec<u8>,
-}
-
-/// PHC strings from the C reference / argon2-rust use `m,t,p`.
-/// `@phc/format` (node-argon2) serializes object insertion order `m,p,t`.
-/// Accept either, plus a missing `$v=` (version 16).
-fn decode_phc(encoded: &str) -> Result<DecodedPhc> {
-  let mut parts = encoded.split('$');
-  if parts.next() != Some("") {
-    return decode_fail();
-  }
-
-  let algorithm = match parts.next() {
-    Some("argon2id") => Argon2Algorithm::Argon2id,
-    Some("argon2i") => Argon2Algorithm::Argon2i,
-    Some("argon2d") => Argon2Algorithm::Argon2d,
-    _ => return decode_fail(),
-  };
-
-  let mut next = match parts.next() {
-    Some(part) => part,
-    None => return decode_fail(),
-  };
-
-  let version = if let Some(raw) = next.strip_prefix("v=") {
-    next = match parts.next() {
-      Some(part) => part,
-      None => return decode_fail(),
-    };
-    match raw.parse::<u32>() {
-      Ok(0x10) => Argon2Version::V0x10,
-      Ok(0x13) => Argon2Version::V0x13,
-      _ => return decode_fail(),
-    }
-  } else {
-    Argon2Version::V0x10
-  };
-
-  let mut memory = None;
-  let mut passes = None;
-  let mut lanes = None;
-  let mut ad = Vec::new();
-  for field in next.split(',') {
-    let Some((key, value)) = field.split_once('=') else {
-      return decode_fail();
-    };
-    match key {
-      "m" => memory = Some(parse_phc_u32(value)?),
-      "t" => passes = Some(parse_phc_u32(value)?),
-      "p" => lanes = Some(parse_phc_u32(value)?),
-      // node-argon2 / @phc/format stores associated data here. It is not
-      // produced by this binding, but verify must honour it.
-      "data" => ad = decode_b64(value)?,
-      _ => {}
-    }
-  }
-
-  let (Some(memory), Some(passes), Some(lanes)) = (memory, passes, lanes) else {
-    return decode_fail();
-  };
-
-  let salt = decode_b64(match parts.next() {
-    Some(part) => part,
-    None => return decode_fail(),
-  })?;
-  let hash = decode_b64(match parts.next() {
-    Some(part) => part,
-    None => return decode_fail(),
-  })?;
-  if parts.next().is_some() {
-    return decode_fail();
-  }
-
-  let params = Params::builder()
-    .memory(Memory::kib(memory as u64))
-    .passes(passes)
-    .lanes(lanes)
-    .threads(thread_budget(lanes))
-    .tag_len(TagLen::bytes(hash.len() as u64))
+fn decode_hashed(encoded: &str) -> Result<argon2_rust::Decoded> {
+  let mut decoded = argon2_rust::decode_phc(encoded).map_err(map_error)?;
+  decoded.params = decoded
+    .params
+    .to_builder()
+    .threads(thread_budget(decoded.params.lanes()))
     .build()
     .map_err(map_error)?;
-
-  Ok(DecodedPhc {
-    algorithm,
-    version,
-    params,
-    salt,
-    hash,
-    ad,
-  })
-}
-
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-  if a.len() != b.len() {
-    return false;
-  }
-  let mut diff = 0u8;
-  for (left, right) in a.iter().zip(b) {
-    diff |= left ^ right;
-  }
-  diff == 0
+  Ok(decoded)
 }
 
 pub struct HashTask {
@@ -480,20 +338,19 @@ impl Task for VerifyTask {
   type JsValue = bool;
 
   fn compute(&mut self) -> Result<Self::Output> {
-    let decoded = decode_phc(&self.hashed)?;
+    let decoded = decode_hashed(&self.hashed)?;
     let argon2 = Argon2::new(decoded.algorithm, decoded.version, decoded.params);
-    let secret = self.options.secret();
-    let mut computed = try_zeroed(decoded.hash.len())?;
-    argon2
-      .hash_into_with_ad(
-        self.password.as_bytes(),
-        &decoded.salt,
-        secret,
-        &decoded.ad,
-        &mut computed,
-      )
-      .map_err(map_error)?;
-    Ok(constant_time_eq(&computed, &decoded.hash))
+    match argon2.verify_with_ad(
+      self.password.as_bytes(),
+      &decoded.salt,
+      self.options.secret(),
+      &decoded.ad,
+      &decoded.hash,
+    ) {
+      Ok(()) => Ok(true),
+      Err(Argon2Error::VerifyMismatch) => Ok(false),
+      Err(err) => Err(map_error(err)),
+    }
   }
 
   fn resolve(&mut self, _env: Env, output: Self::Output) -> Result<Self::JsValue> {
@@ -532,30 +389,4 @@ pub fn verify_sync(
   };
   let output = verify_task.compute()?;
   verify_task.resolve(env, output)
-}
-
-#[cfg(test)]
-mod tests {
-  use super::{decode_b64, encode_b64};
-
-  #[test]
-  fn phc_base64_round_trips_salt_and_tag_sizes() {
-    for n in [8usize, 16, 32, 33] {
-      let src: Vec<u8> = (0..n).map(|i| i as u8).collect();
-      let encoded = encode_b64(&src);
-      assert_eq!(decode_b64(&encoded).unwrap(), src);
-    }
-  }
-
-  #[test]
-  fn phc_base64_matches_known_unpadded() {
-    assert_eq!(encode_b64(b"somesalt"), "c29tZXNhbHQ");
-    assert_eq!(decode_b64("c29tZXNhbHQ").unwrap(), b"somesalt");
-  }
-
-  #[test]
-  fn phc_base64_rejects_bad_length_and_bits() {
-    assert!(decode_b64("A").is_err());
-    assert!(decode_b64("????").is_err());
-  }
 }

--- a/packages/argon2/src/lib.rs
+++ b/packages/argon2/src/lib.rs
@@ -200,68 +200,17 @@ fn generate_salt() -> [u8; argon2_rust::RANDOM_SALT_LEN] {
   rand::random()
 }
 
-const B64_ENCODE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-const B64_DECODE: [u8; 256] = {
-  let mut table = [0xFFu8; 256];
-  let mut i = 0;
-  while i < 26 {
-    table[(b'A' + i) as usize] = i;
-    table[(b'a' + i) as usize] = 26 + i;
-    i += 1;
-  }
-  i = 0;
-  while i < 10 {
-    table[(b'0' + i) as usize] = 52 + i;
-    i += 1;
-  }
-  table[b'+' as usize] = 62;
-  table[b'/' as usize] = 63;
-  table
-};
-
-fn encode_b64(src: &[u8]) -> String {
-  let n = src.len();
-  let out_len = n / 3 * 4 + [0, 2, 3][n % 3];
-  let mut out = Vec::with_capacity(out_len);
-  let mut i = 0;
-  while i + 3 <= n {
-    let triple = ((src[i] as u32) << 16) | ((src[i + 1] as u32) << 8) | src[i + 2] as u32;
-    out.push(B64_ENCODE[((triple >> 18) & 63) as usize]);
-    out.push(B64_ENCODE[((triple >> 12) & 63) as usize]);
-    out.push(B64_ENCODE[((triple >> 6) & 63) as usize]);
-    out.push(B64_ENCODE[(triple & 63) as usize]);
-    i += 3;
-  }
-  match n - i {
-    1 => {
-      let rem = (src[i] as u32) << 16;
-      out.push(B64_ENCODE[((rem >> 18) & 63) as usize]);
-      out.push(B64_ENCODE[((rem >> 12) & 63) as usize]);
-    }
-    2 => {
-      let rem = ((src[i] as u32) << 16) | ((src[i + 1] as u32) << 8);
-      out.push(B64_ENCODE[((rem >> 18) & 63) as usize]);
-      out.push(B64_ENCODE[((rem >> 12) & 63) as usize]);
-      out.push(B64_ENCODE[((rem >> 6) & 63) as usize]);
-    }
-    _ => {}
-  }
-  // SAFETY: every byte is from the ASCII Base64 alphabet.
-  unsafe { String::from_utf8_unchecked(out) }
-}
-
-fn encode_phc(argon2: &Argon2, salt: &[u8], tag: &[u8]) -> String {
-  format!(
+fn encode_phc(argon2: &Argon2, salt: &[u8], tag: &[u8]) -> Result<String> {
+  Ok(format!(
     "${}$v={}$m={},t={},p={}${}${}",
     argon2.algorithm().as_str(),
     argon2.version().as_u32(),
     argon2.params().memory_kib(),
     argon2.params().passes(),
     argon2.params().lanes(),
-    encode_b64(salt),
-    encode_b64(tag),
-  )
+    argon2_rust::encode_base64(salt).map_err(map_error)?,
+    argon2_rust::encode_base64(tag).map_err(map_error)?,
+  ))
 }
 
 fn hash_encoded(argon2: &Argon2, password: &[u8], salt: &[u8], secret: &[u8]) -> Result<String> {
@@ -272,7 +221,7 @@ fn hash_encoded(argon2: &Argon2, password: &[u8], salt: &[u8], secret: &[u8]) ->
   argon2
     .hash_into_with_ad(password, salt, secret, &[], &mut tag)
     .map_err(map_error)?;
-  Ok(encode_phc(argon2, salt, &tag))
+  encode_phc(argon2, salt, &tag)
 }
 
 fn hash_raw_bytes(argon2: &Argon2, password: &[u8], salt: &[u8], secret: &[u8]) -> Result<Vec<u8>> {
@@ -295,54 +244,7 @@ fn parse_phc_u32(value: &str) -> Result<u32> {
 }
 
 fn decode_b64(input: &str) -> Result<Vec<u8>> {
-  let src = input.as_bytes();
-  let n = src.len();
-  let out_len = match n % 4 {
-    0 => n / 4 * 3,
-    2 => n / 4 * 3 + 1,
-    3 => n / 4 * 3 + 2,
-    _ => return decode_fail(),
-  };
-  let mut out = try_zeroed(out_len)?;
-  let mut i = 0;
-  let mut o = 0;
-  while i + 4 <= n {
-    let a = B64_DECODE[src[i] as usize];
-    let b = B64_DECODE[src[i + 1] as usize];
-    let c = B64_DECODE[src[i + 2] as usize];
-    let d = B64_DECODE[src[i + 3] as usize];
-    if a | b | c | d == 0xFF {
-      return decode_fail();
-    }
-    out[o] = (a << 2) | (b >> 4);
-    out[o + 1] = (b << 4) | (c >> 2);
-    out[o + 2] = (c << 6) | d;
-    i += 4;
-    o += 3;
-  }
-  match n - i {
-    0 => {}
-    2 => {
-      let a = B64_DECODE[src[i] as usize];
-      let b = B64_DECODE[src[i + 1] as usize];
-      if a == 0xFF || b == 0xFF || b & 0x0F != 0 {
-        return decode_fail();
-      }
-      out[o] = (a << 2) | (b >> 4);
-    }
-    3 => {
-      let a = B64_DECODE[src[i] as usize];
-      let b = B64_DECODE[src[i + 1] as usize];
-      let c = B64_DECODE[src[i + 2] as usize];
-      if a == 0xFF || b == 0xFF || c == 0xFF || c & 0x03 != 0 {
-        return decode_fail();
-      }
-      out[o] = (a << 2) | (b >> 4);
-      out[o + 1] = (b << 4) | (c >> 2);
-    }
-    _ => return decode_fail(),
-  }
-  Ok(out)
+  argon2_rust::decode_base64(input.as_bytes()).map_err(map_error)
 }
 
 struct DecodedPhc {

--- a/packages/argon2/src/lib.rs
+++ b/packages/argon2/src/lib.rs
@@ -7,7 +7,6 @@ use argon2_rust::{
   Algorithm as Argon2Algorithm, Argon2, Error as Argon2Error, Params, Version as Argon2Version,
   params::{Memory, TagLen},
 };
-use base64::Engine;
 use napi::bindgen_prelude::*;
 use napi_derive::napi;
 
@@ -201,6 +200,57 @@ fn generate_salt() -> [u8; argon2_rust::RANDOM_SALT_LEN] {
   rand::random()
 }
 
+const B64_ENCODE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+const B64_DECODE: [u8; 256] = {
+  let mut table = [0xFFu8; 256];
+  let mut i = 0;
+  while i < 26 {
+    table[(b'A' + i) as usize] = i;
+    table[(b'a' + i) as usize] = 26 + i;
+    i += 1;
+  }
+  i = 0;
+  while i < 10 {
+    table[(b'0' + i) as usize] = 52 + i;
+    i += 1;
+  }
+  table[b'+' as usize] = 62;
+  table[b'/' as usize] = 63;
+  table
+};
+
+fn encode_b64(src: &[u8]) -> String {
+  let n = src.len();
+  let out_len = n / 3 * 4 + [0, 2, 3][n % 3];
+  let mut out = Vec::with_capacity(out_len);
+  let mut i = 0;
+  while i + 3 <= n {
+    let triple = ((src[i] as u32) << 16) | ((src[i + 1] as u32) << 8) | src[i + 2] as u32;
+    out.push(B64_ENCODE[((triple >> 18) & 63) as usize]);
+    out.push(B64_ENCODE[((triple >> 12) & 63) as usize]);
+    out.push(B64_ENCODE[((triple >> 6) & 63) as usize]);
+    out.push(B64_ENCODE[(triple & 63) as usize]);
+    i += 3;
+  }
+  match n - i {
+    1 => {
+      let rem = (src[i] as u32) << 16;
+      out.push(B64_ENCODE[((rem >> 18) & 63) as usize]);
+      out.push(B64_ENCODE[((rem >> 12) & 63) as usize]);
+    }
+    2 => {
+      let rem = ((src[i] as u32) << 16) | ((src[i + 1] as u32) << 8);
+      out.push(B64_ENCODE[((rem >> 18) & 63) as usize]);
+      out.push(B64_ENCODE[((rem >> 12) & 63) as usize]);
+      out.push(B64_ENCODE[((rem >> 6) & 63) as usize]);
+    }
+    _ => {}
+  }
+  // SAFETY: every byte is from the ASCII Base64 alphabet.
+  unsafe { String::from_utf8_unchecked(out) }
+}
+
 fn encode_phc(argon2: &Argon2, salt: &[u8], tag: &[u8]) -> String {
   format!(
     "${}$v={}$m={},t={},p={}${}${}",
@@ -209,8 +259,8 @@ fn encode_phc(argon2: &Argon2, salt: &[u8], tag: &[u8]) -> String {
     argon2.params().memory_kib(),
     argon2.params().passes(),
     argon2.params().lanes(),
-    base64::engine::general_purpose::STANDARD_NO_PAD.encode(salt),
-    base64::engine::general_purpose::STANDARD_NO_PAD.encode(tag),
+    encode_b64(salt),
+    encode_b64(tag),
   )
 }
 
@@ -245,14 +295,54 @@ fn parse_phc_u32(value: &str) -> Result<u32> {
 }
 
 fn decode_b64(input: &str) -> Result<Vec<u8>> {
-  base64::engine::general_purpose::STANDARD_NO_PAD
-    .decode(input)
-    .map_err(|_| {
-      Error::new(
-        Status::InvalidArg,
-        format!("Invalid hashed password: {}", Argon2Error::DecodingFail),
-      )
-    })
+  let src = input.as_bytes();
+  let n = src.len();
+  let out_len = match n % 4 {
+    0 => n / 4 * 3,
+    2 => n / 4 * 3 + 1,
+    3 => n / 4 * 3 + 2,
+    _ => return decode_fail(),
+  };
+  let mut out = try_zeroed(out_len)?;
+  let mut i = 0;
+  let mut o = 0;
+  while i + 4 <= n {
+    let a = B64_DECODE[src[i] as usize];
+    let b = B64_DECODE[src[i + 1] as usize];
+    let c = B64_DECODE[src[i + 2] as usize];
+    let d = B64_DECODE[src[i + 3] as usize];
+    if a | b | c | d == 0xFF {
+      return decode_fail();
+    }
+    out[o] = (a << 2) | (b >> 4);
+    out[o + 1] = (b << 4) | (c >> 2);
+    out[o + 2] = (c << 6) | d;
+    i += 4;
+    o += 3;
+  }
+  match n - i {
+    0 => {}
+    2 => {
+      let a = B64_DECODE[src[i] as usize];
+      let b = B64_DECODE[src[i + 1] as usize];
+      if a == 0xFF || b == 0xFF || b & 0x0F != 0 {
+        return decode_fail();
+      }
+      out[o] = (a << 2) | (b >> 4);
+    }
+    3 => {
+      let a = B64_DECODE[src[i] as usize];
+      let b = B64_DECODE[src[i + 1] as usize];
+      let c = B64_DECODE[src[i + 2] as usize];
+      if a == 0xFF || b == 0xFF || c == 0xFF || c & 0x03 != 0 {
+        return decode_fail();
+      }
+      out[o] = (a << 2) | (b >> 4);
+      out[o + 1] = (b << 4) | (c >> 2);
+    }
+    _ => return decode_fail(),
+  }
+  Ok(out)
 }
 
 struct DecodedPhc {
@@ -540,4 +630,30 @@ pub fn verify_sync(
   };
   let output = verify_task.compute()?;
   verify_task.resolve(env, output)
+}
+
+#[cfg(test)]
+mod tests {
+  use super::{decode_b64, encode_b64};
+
+  #[test]
+  fn phc_base64_round_trips_salt_and_tag_sizes() {
+    for n in [8usize, 16, 32, 33] {
+      let src: Vec<u8> = (0..n).map(|i| i as u8).collect();
+      let encoded = encode_b64(&src);
+      assert_eq!(decode_b64(&encoded).unwrap(), src);
+    }
+  }
+
+  #[test]
+  fn phc_base64_matches_known_unpadded() {
+    assert_eq!(encode_b64(b"somesalt"), "c29tZXNhbHQ");
+    assert_eq!(decode_b64("c29tZXNhbHQ").unwrap(), b"somesalt");
+  }
+
+  #[test]
+  fn phc_base64_rejects_bad_length_and_bits() {
+    assert!(decode_b64("A").is_err());
+    assert!(decode_b64("????").is_err());
+  }
 }

--- a/packages/argon2/src/lib.rs
+++ b/packages/argon2/src/lib.rs
@@ -189,7 +189,10 @@ fn utf8_input(value: Either<String, &[u8]>) -> Result<String> {
   match value {
     Either::A(s) => Ok(s),
     Either::B(b) => {
-      String::from_utf8(b.to_vec()).map_err(|err| Error::new(Status::InvalidArg, format!("{err}")))
+      simdutf8::basic::from_utf8(b)
+        .map_err(|err| Error::new(Status::InvalidArg, format!("{err}")))?;
+      // SAFETY: `from_utf8` just accepted these bytes as UTF-8.
+      Ok(unsafe { String::from_utf8_unchecked(b.to_vec()) })
     }
   }
 }


### PR DESCRIPTION
## Summary

- Validate verify inputs with `simdutf8`, then `String::from_utf8_unchecked` on the owned bytes.
- Decode PHC salt/tag through argon2-rust SIMD Base64 (the local LUT is gone).
- Require [`argon2-rust`](https://crates.io/crates/argon2-rust) **1.1** from crates.io (no sibling path dep).
- Drop the binding's PHC parser, encoder, and compare. Hash/verify use `hash_encoded_with_ad`, `decode_phc`, and `verify_with_ad`.
- Still clamp `p` to `available_parallelism` so a hostile string does not spawn extra OS threads.
- JS API unchanged.

## Test plan

- [x] `yarn workspace @node-rs/argon2 build:debug`
- [x] `yarn ava packages/argon2/__test__/argon2.spec.ts` (13 passed, including `data=` vs `node:crypto`)
- [ ] CI on this PR