### PR TITLE
fix: disable mimalloc architecture optimizations on Linux ARM64

### DIFF
--- a/crates/alloc/Cargo.toml
+++ b/crates/alloc/Cargo.toml
@@ -10,3 +10,7 @@ mimalloc-safe = { workspace = true, features = ["skip_collect_on_exit"] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 mimalloc-safe = { workspace = true, features = ["skip_collect_on_exit", "local_dynamic_tls"] }
+
+# Keep Linux ARM64 compatible with CPUs without ARMv8.1 LSE atomics.
+[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
+mimalloc-safe = { workspace = true, features = ["no_opt_arch"] }


### PR DESCRIPTION
`@node-rs/bcrypt@1.10.8` crashes during module loading on Raspberry Pi 4 because its bundled mimalloc allocator emits unconditional ARMv8.1 LSE atomics. Enable `mimalloc-safe/no_opt_arch` for Linux AArch64, covering GNU and musl, while preserving the existing macOS and Windows AArch64 optimization settings.

The feature sets both `MI_OPT_ARCH=OFF` and `MI_NO_OPT_ARCH=ON`; the latter prevents mimalloc's ARM64 defaults from enabling architecture optimizations again. Existing allocator TLS and exit-collection features are preserved.

Fixes #1199.

Validation:

- Checked Cargo feature resolution for Linux AArch64 GNU/musl, macOS AArch64, Windows AArch64, Linux x86_64, Android AArch64, FreeBSD AArch64, and WASI. Only Linux AArch64 enables `no_opt_arch`.
- Rebuilt the GNU ARM64 bcrypt addon with Rust 1.98.0 and Clang 14, and confirmed both CMake overrides and the absence of the forced `-march=armv8.1-a` compiler flag.
- The rebuilt addon passes loading, synchronous/asynchronous hashing and verification, salt generation, and worker loading/execution/exit under QEMU Cortex-A72, Cortex-A53, and `max`.

Runtime validation used emulation; physical Raspberry Pi testing and native macOS/Windows builds were not run.
