### PR TITLE
fix: remove forced SSE4.2 from x64 builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,3 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-feature=+sse4.2"]
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+sse4.2"]
+# Keep the default x86 CPU baseline; CRC implementations detect SIMD support at runtime.
 [target.aarch64-unknown-linux-musl]
 rustflags = ["-C", "target-feature=-crt-static"]


### PR DESCRIPTION
Published CRC32 addons crash during module registration on older x64 CPUs without SSSE3. The global `+sse4.2` compiler flag permits unsupported instructions throughout the addon and makes SSE4.2 feature checks unconditionally true.

Remove the forced feature from Linux GNU and Windows MSVC x64 builds. `crc32fast` and `crc32c` already select accelerated implementations at runtime, so newer CPUs retain hardware acceleration while older CPUs can use the software paths.

Fixes #1016.

Validation:

- Reproduced SIGILL in published GNU x64 versions 1.10.6 and 1.10.7 under QEMU's Opteron G3 model; GDB confirmed `pshufb` as the faulting instruction in 1.10.6.
- Rebuilt the GNU x64 addon with Rust 1.98.1 and tested it using Node 18.20.8 under Opteron G3, `qemu64` with SSSE3/SSE4.1/SSE4.2/PCLMUL disabled, and `max`.
- All three CPU models pass module loading, standard CRC vectors, 324 buffer cases covering lengths, alignment and initial states, incremental checksums, and UTF-8 string inputs.
- Confirmed the rebuilt binary still contains accelerated CRC32 and PCLMUL instructions. Formatting and whitespace checks pass.

Runtime validation used Linux CPU emulation. Native Windows execution and physical older-CPU testing were not performed.
